### PR TITLE
Fix: Correct repository user to VisualBoy a

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -10,7 +10,7 @@ https://community.octoprint.org
 All support related questions will be closed.
 
 Feature requests should be made at:
-https://feathub.com/kantlivelong/OctoPrint-GCodeSystemCommands
+https://feathub.com/VisualBoy/OctoPrint-LiveGCodeControl
 
 When reporting a bug do NOT delete ANY lines from the template.
 

--- a/octoprint_livegcodecontrol/__init__.py
+++ b/octoprint_livegcodecontrol/__init__.py
@@ -135,12 +135,12 @@ class LiveGCodeControlPlugin(octoprint.plugin.SettingsPlugin,
 
                 # version check: github repository
                 type="github_release",
-                user="JulesGraus", # Update with your GitHub username
+                user="VisualBoy", # Update with your GitHub username
                 repo="OctoPrint-LiveGCodeControl",
                 current=self._plugin_version,
 
                 # update method: pip
-                pip="https://github.com/JulesGraus/OctoPrint-LiveGCodeControl/archive/{target_version}.zip"
+                pip="https://github.com/VisualBoy/OctoPrint-LiveGCodeControl/archive/{target_version}.zip"
             )
         )
 


### PR DESCRIPTION
This commit corrects the repository owner information 

- Updated .github/ISSUE_TEMPLATE.md to reference VisualBoy/OctoPrint-LiveGCodeControl and the OctoPrint-LiveGCodeControl plugin.
- Updated .github/PULL_REQUEST_TEMPLATE.md to reference OctoPrint-LiveGCodeControl 
- Updated `octoprint_livegcodecontrol/__init__.py` 
